### PR TITLE
fix: adding config as location

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is an example server with a single endpoint of `/chargeForCookie` for proce
 * Go to the [Square Application Dashboard](https://developer.squareup.com/apps) and select your application.
 * Copy the **Personal Access Token** from the **Credentials** tab into the `ACCESS_TOKEN` field of the Heroku configuration page.
 * Specify the environment by setting **ENVIRONMENT**. Sandbox use - `SANDBOX`; Production use - `PRODUCTION`.
+* Copy your location ID from the Locations tab of the [Square Developer Dashboard](https://developer.squareup.com/apps) to the **LOCATION_ID** field of the Heroku configuration page.
 * Click **Deploy app**
 * Copy `https://[Heroku app name].herokuapp.com/chargeForCookie` as your URL to POST to in your mobile application.
 
@@ -38,4 +39,4 @@ curl -X POST 'https://[Heroku app name].herokuapp.com/chargeForCookie' \
 * Specify the environment by setting **ENVIRONMENT**. Sandbox use - `SANDBOX`; Production use - `PRODUCTION`.
 * Run the following command in the root folder of this project:
 
-    `PORT=8000 ACCESS_TOKEN={{Replace_with_personal_access_token}} ENVIRONMENT=SANDBOX node index.js`
+    `PORT=8000 ACCESS_TOKEN={{Replace_with_personal_access_token}} ENVIRONMENT=SANDBOX LOCATION_ID={{Replace_with_location_id}} node index.js`

--- a/app.json
+++ b/app.json
@@ -9,6 +9,10 @@
     "ENVIRONMENT": {
       "description": "For sandbox testing use \"SANDBOX\", for production use \"PRODUCTION\".",
       "required": true
+    },
+    "LOCATION_ID": {
+      "description": "The location to charge your payment to. You can find your location ID in the Locations section of the Square Developer Dashboard [https://developer.squareup.com/apps/]",
+      "required": true
     }
   },
   "scripts": {

--- a/index.js
+++ b/index.js
@@ -20,8 +20,7 @@ const { paymentsApi, ordersApi, locationsApi, customersApi } = defaultClient;
 app.post('/chargeForCookie', async (request, response) => {
   const requestBody = request.body;
   try {
-    const listLocationsResponse = await locationsApi.listLocations();
-    const locationId = listLocationsResponse.result.locations[0].id;
+    const locationId =  process.env.LOCATION_ID;
     const createOrderRequest = getOrderRequest(locationId);
     const createOrderResponse = await ordersApi.createOrder(createOrderRequest);
 
@@ -33,6 +32,7 @@ app.post('/chargeForCookie', async (request, response) => {
       },
       orderId: createOrderResponse.result.order.id,
       autocomplete: true,
+      locationId,
     };
     const createPaymentResponse = await paymentsApi.createPayment(createPaymentRequest);
     console.log(createPaymentResponse.result.payment);
@@ -51,7 +51,7 @@ app.post('/chargeCustomerCard', async (request, response) => {
 
   try {
     const listLocationsResponse = await locationsApi.listLocations();
-    const locationId = listLocationsResponse.result.locations[0].id;
+    const locationId = process.env.LOCATION_ID;
     const createOrderRequest = getOrderRequest(locationId);
     const createOrderResponse = await ordersApi.createOrder(createOrderRequest);
     const createPaymentRequest = {


### PR DESCRIPTION
Replacing the calls to `locationsAPI` with a configurable location ID, which can be consistently used across the [quick start guide](https://developer.squareup.com/docs/in-app-payments-sdk/quick-start/).

Tested API locally using env vars.

Tested that Heroku picks up the new config value:
![Screen Shot 2022-04-07 at 5 25 46 PM](https://user-images.githubusercontent.com/1880814/162340141-ad616ecd-3d8a-4c28-8c47-dcadbde00d54.png)
 